### PR TITLE
Add cargo-make file with static build commands + small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ See [this article](https://www.synacktiv.com/publications/systemd-hardening-made
 
 ## Installation
 
+### Dependencies
+
+Strace needs to be installed and available in the path. Strace version >=6.4 is strongly recommended.
+
 ### From source
 
 You need a Rust build environment for example from [rustup](https://rustup.rs/).


### PR DESCRIPTION
Thanks for building this tool! I have a scenario where I need to be able to quickly deploy this on a heterogeneous set of hosts so I looked into the possibility of building shh as a static binary for easier deployment. It turns out that this works great with the right build flags.

I added a [cargo-make](https://sagiegurari.github.io/cargo-make/) file with the commands so that it's easy to build a static binary by running `cargo make build-static-release`. I also made sure to run the tests which can also be run with `cargo make test-all-static` and finally I went through the Caddy example from the article by first building the binary on my Ubuntu machine, uploading it to a Debian 12 machine and going through the example which worked great.

I also took the opportunity to update the dependencies ~~and apply a small clippy suggestion~~.