### PR TITLE
WIP manual and autocomplete generation support in build.rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,8 @@ jobs:
           profile: minimal
           toolchain: stable
           target: x86_64-unknown-linux-gnu
-      - run: |
-          mkdir -p target/man
-          cargo run --features gen-man-pages -- target/man
-          gzip -9 target/man/*.1
+      #- run: |
+      #    gzip -9 target/assets/man/*.1
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +776,7 @@ dependencies = [
  "assert_cmd",
  "bincode",
  "clap",
+ "clap_complete",
  "clap_mangen",
  "const-gen",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ codegen-units = 1
 strip = true
 
 [build-dependencies]
+clap = { version = "4.5.36", default-features = false, features = ["std", "color", "help", "usage", "error-context", "suggestions", "derive", "string"] }
+clap_complete = { version = "4.5.47", default-features = false, optional = true }
+clap_mangen = { version = "0.2.26", default-features = false, optional = true }
 const-gen = { version = "1.6.6", default-features = false, features = ["std", "phf"] }
+strum = { version = "0.27.1", default-features = false, features = ["std", "derive"] }
 
 [dependencies]
 anyhow = { version = "1.0.97", default-features = false, features = ["std", "backtrace"] }
 bincode = { version = "2.0.1", default-features = false, features = ["std", "serde"] }
 clap = { version = "4.5.36", default-features = false, features = ["std", "color", "help", "usage", "error-context", "suggestions", "derive"] }
-clap_mangen = { version = "0.2.26", default-features = false, optional = true }
 function_name = { version = "0.3.0", default-features = false }
 goblin = { version = "0.9.3", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
 itertools = { version = "0.14.0", default-features = false, features = ["use_std"] }
@@ -57,6 +60,7 @@ pretty_assertions = { version = "1.4.1", default-features = false, features = ["
 default = []
 as-root = [] # for tests only
 gen-man-pages = ["dep:clap_mangen"]
+gen-shell-compl = ["dep:clap_complete"]
 nightly = [] # for benchmarks only
 
 [lints.rust]
@@ -128,7 +132,9 @@ verbose_file_reads = "warn"
 [package.metadata.deb]
 name = "shh"
 depends = "$auto, strace"
+features = ["gen-man-pages"]
 assets = [
   ["target/release/shh", "usr/bin/", "755"],
-  ["target/man/*.1.gz", "usr/share/man/man1/", "644"]
+#  ["target/assets/man/*.1.gz", "usr/share/man/man1/", "644"]
+  ["target/assets/man/*.1", "usr/share/man/man1/", "644"] # todo fix this to compress manpages while building
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
 //! Systemd Hardening Helper
 
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
-#![cfg_attr(
-    feature = "gen-man-pages",
-    expect(dead_code, unused_crate_dependencies, unused_imports)
-)]
 
 use std::{
     env,
@@ -62,20 +58,6 @@ fn edit_file(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "gen-man-pages")]
-fn main() -> anyhow::Result<()> {
-    use clap::CommandFactory as _;
-
-    // Use the binary name instead of the default of the package name
-    let cmd = cl::Args::command().name(env!("CARGO_BIN_NAME"));
-    let output = env::args_os()
-        .nth(1)
-        .ok_or_else(|| anyhow::anyhow!("Missing output dir argument"))?;
-    clap_mangen::generate_to(cmd, output)?;
-    Ok(())
-}
-
-#[cfg(not(feature = "gen-man-pages"))]
 fn main() -> anyhow::Result<()> {
     // Init logger
     simple_logger::SimpleLogger::new()


### PR DESCRIPTION
A work in progress attempt at streamlining the build process for manpages and shell-autocomplete.
This is not yet ready to be merged due to lacking manpage compression.
The cargo toml is also less than optimal due to me copy-pasting a lot.

The manpages and shell-completion are automatically generated by build.rs before the bin compilation.

This might have been better done by cargo xtasks but i digress.